### PR TITLE
Normalize abandoned combat state during FastQuit

### DIFF
--- a/EventLib.pas
+++ b/EventLib.pas
@@ -11,6 +11,11 @@ uses
 
 
 type
+  POnBeforeFastQuitToGameMenuEvent = ^TOnBeforeFastQuitToGameMenuEvent;
+  TOnBeforeFastQuitToGameMenuEvent = packed record
+    TargetScreen: integer;
+  end;
+
   POnBeforeLoadGameEvent = ^TOnBeforeLoadGameEvent;
   TOnBeforeLoadGameEvent = packed record
     FileName: pchar;

--- a/Triggers.pas
+++ b/Triggers.pas
@@ -631,7 +631,34 @@ procedure Splice_ExecuteManager (OrigFunc: pointer; This: pointer); stdcall;
 var
   ExceptionRegistration: TDelphiExceptionRegistration;
   Left:                  boolean;
+  IsFastQuit:            boolean;
   ShouldFastQuit:        boolean;
+  FastQuitEvent:         EventLib.TOnBeforeFastQuitToGameMenuEvent;
+
+  procedure NormalizeFastQuitState;
+  const
+    ADV_MANAGER_PTR          = $6992B8;
+    IN_COMBAT_FLAG           = $699590;
+    ADV_DISPOSAL_MODE        = $699598;
+    MON_ATTACK_OBJ_INDEX_OFS = $218;
+    MON_ATTACK_FRAME_OFS     = $21C;
+    MON_ATTACK_FLIP_OFS      = $220;
+
+  var
+    AdvManager: pointer;
+
+  begin
+    pboolean(IN_COMBAT_FLAG)^    := false;
+    pinteger(ADV_DISPOSAL_MODE)^ := 0;
+
+    AdvManager := ppointer(ADV_MANAGER_PTR)^;
+
+    if AdvManager <> nil then begin
+      pinteger(integer(AdvManager) + MON_ATTACK_OBJ_INDEX_OFS)^ := -1;
+      pinteger(integer(AdvManager) + MON_ATTACK_FRAME_OFS)^     := -1;
+      pinteger(integer(AdvManager) + MON_ATTACK_FLIP_OFS)^      := 0;
+    end;
+  end;
 
   function Leave: boolean;
   begin
@@ -651,6 +678,15 @@ var
           end;
 
           Erm.FireErmEvent(Erm.TRIGGER_ONGAMELEAVE);
+
+          if IsFastQuit then begin
+            try
+              EventMan.GetInstance.Fire('OnBeforeFastQuitToGameMenu', @FastQuitEvent, sizeof(FastQuitEvent));
+            finally
+              NormalizeFastQuitState;
+            end;
+          end;
+
           EventMan.GetInstance.Fire('OnGameLeft');
         end;
       end;
@@ -662,7 +698,9 @@ var
 begin
   Inc(MainGameLoopDepth);
   Left           := false;
+  IsFastQuit     := false;
   ShouldFastQuit := false;
+  FastQuitEvent.TargetScreen := 0;
 
   try
     EnhanceExceptionHandler(@ExceptionRegistration);
@@ -677,6 +715,8 @@ begin
     if (ExceptionRecord.ExceptionCode = EXCEPTION_CODE_ERA) and (ExceptionArgs[0] = EXCEPTION_ERA_FAST_QUIT_TO_GAME_MENU) then begin
       Erm.PerformCleanupOnExceptions := false;
       Heroes.MainMenuTarget^         := ExceptionArgs[1];
+      IsFastQuit                     := true;
+      FastQuitEvent.TargetScreen     := ExceptionArgs[1];
       ShouldFastQuit                 := not Leave;
     end else begin
       Tweaks.ProcessUnhandledException(ExceptionRecord, ExceptionContext);


### PR DESCRIPTION
## Summary

Make `FastQuitToGameMenu` clean up transient combat and adventure-map state that is normally restored only after the combat manager returns.

## Changes

- Add `OnBeforeFastQuitToGameMenu`, carrying the requested target screen.
- Fire the event after ordinary `OnGameLeave` handlers and before `OnGameLeft`.
- Reset `gbInCombat` after plugin cleanup.
- Reset the adventure disposal mode before `advManager::Close`, allowing cached graphics and `avwattak.def` resources to be released normally.
- Clear the neutral-monster attack overlay indices and direction state.
- Guarantee ERA's core cleanup through a `finally` block.
- Preserve the game's existing SEH manager-unwind path.

## Motivation

FastQuit leaves combat by raising an ERA service exception. This bypasses the normal tail of `advManager::DoCombat`, which can leave:

- the attacked neutral creature displayed using a stuck `avwattak.def` frame;
- `gbInCombat` set after returning to the menu;
- adventure disposal mode enabled, causing `advManager::Close` to skip resource release;
- plugin-owned battle-local state without a precise FastQuit cleanup event.

Repeated FastQuit/load cycles may consequently retain adventure graphics and increase memory pressure in the 32-bit process.

## Ordering

Normal `OnGameLeave` handlers still observe the original combat state. The new FastQuit-specific event follows them, then ERA normalizes its core state before `OnGameLeft` and adventure-manager disposal.

The patch deliberately does not call `OnAfterBattle`, force battle results, or manually close combat managers.